### PR TITLE
Fix for NuGet failure 

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,10 +26,7 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
-    <None Include="..\..\README.md">
-      <Pack>True</Pack>
-      <PackagePath></PackagePath>
-    </None>
+    <None Include="..\..\README.md" Pack="false" PackagePath="\" />
   </ItemGroup>
 
 


### PR DESCRIPTION
The build props file readme was causing a NuGet duplicate file error.  